### PR TITLE
Patch candidate for OSGi support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ assert typeArgs[0] == HashSet.class;
 assert typeArgs[1] == ArrayList.class;
 ```
 
-Type arguments can also be resolved for lambda expressions:
+Type arguments can also be resolved from lambda expressions:
 
 ```java
 Function<String, Integer> strToInt = s -> Integer.valueOf(s);
@@ -55,7 +55,7 @@ assert typeArgs[0] == String.class;
 assert typeArgs[1] == Integer.class;
 ```
 
-And for method references:
+And from method references:
 
 ```java
 Comparator<String> comparator = String::compareToIgnoreCase;

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>net.jodah</groupId>
   <artifactId>typetools</artifactId>
   <version>0.4.1-SNAPSHOT</version>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <name>TypeTools</name>
   <url>http://github.com/jhalterman/typetools/</url>
 
@@ -129,6 +129,22 @@
           </execution>
         </executions>
       </plugin>
+	  <plugin>
+		<groupId>org.apache.felix</groupId>
+		<artifactId>maven-bundle-plugin</artifactId>
+		<version>2.5.3</version>
+		<extensions>true</extensions>
+		<configuration>
+		  <instructions>
+			<Implementation-Title>${project.description}</Implementation-Title>
+			<Implementation-Version>${project.version}</Implementation-Version>
+			<Bundle-Name>Type Tools</Bundle-Name>
+			<Bundle-SymbolicName>net.jodah.typetools</Bundle-SymbolicName>
+			<Export-Package>net/jodah/typetools;version=1.0</Export-Package>
+			<Import-Package>*</Import-Package>
+		  </instructions>
+		</configuration>
+	  </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/net/jodah/typetools/TypeDescriptor.java
+++ b/src/main/java/net/jodah/typetools/TypeDescriptor.java
@@ -311,6 +311,17 @@ final class TypeDescriptor {
    * @return the raw class corresponding to this type descriptor
    */
   public Class<?> getType() {
+	  return getType(null);
+  }
+  
+  /**
+   * Returns the raw class corresponding to this type descriptor. Primitive types return their
+   * corresponding wrappers.
+   * 
+   * @param loader the class loader used to load the actual raw class.
+   * @return the raw class corresponding to this type descriptor
+   */
+  public Class<?> getType(ClassLoader loader) {
     try {
       switch (sort) {
         case VOID:
@@ -337,9 +348,10 @@ final class TypeDescriptor {
           for (int i = getDimensions(); i > 0; --i)
             sb.append("[");
           sb.append('L').append(elementType.getType().getName()).append(';');
-          return Class.forName(sb.toString());
+          return loader == null ? Class.forName(sb.toString()) : loader.loadClass(sb.toString());
         case OBJECT:
-          return Class.forName(new String(buf, off, len).replace('/', '.'));
+          String clazz = new String(buf, off, len).replace('/', '.');
+          return loader == null ? Class.forName(clazz) : loader.loadClass(clazz); 
         default:
           return null;
       }

--- a/src/main/java/net/jodah/typetools/TypeResolver.java
+++ b/src/main/java/net/jodah/typetools/TypeResolver.java
@@ -310,7 +310,7 @@ public final class TypeResolver {
               methodRefInfo = constantPool.getMemberRefInfoAt(constantPool.getSize() - 8);
 
             if (returnTypeVar instanceof TypeVariable) {
-              Class<?> returnType = TypeDescriptor.getReturnType(methodRefInfo[2]).getType();
+              Class<?> returnType = TypeDescriptor.getReturnType(methodRefInfo[2]).getType(lambdaType.getClassLoader());
               if (!returnType.equals(Void.class))
                 map.put((TypeVariable<?>) returnTypeVar, returnType);
             }
@@ -320,14 +320,14 @@ public final class TypeResolver {
             // Handle arbitrary object instance method references
             int offset = 0;
             if (paramTypeVars[0] instanceof TypeVariable && paramTypeVars.length == arguments.length + 1) {
-              Class<?> instanceType = TypeDescriptor.getObjectType(methodRefInfo[0]).getType();
+              Class<?> instanceType = TypeDescriptor.getObjectType(methodRefInfo[0]).getType(lambdaType.getClassLoader());
               map.put((TypeVariable<?>) paramTypeVars[0], instanceType);
               offset = 1;
             }
 
             for (int i = 0; i < arguments.length; i++)
               if (paramTypeVars[i + offset] instanceof TypeVariable)
-                map.put((TypeVariable<?>) paramTypeVars[i + offset], arguments[i].getType());
+                map.put((TypeVariable<?>) paramTypeVars[i + offset], arguments[i].getType(lambdaType.getClassLoader()));
             break;
           }
         }


### PR DESCRIPTION
I changed the pom.xml in order to generate an OSGi bundle, using maven-bundle-plugin.

Also, while doing a real test under Felix, I realized that it was not working. I figured out that the TypeResolver class was doing a class.forName in order to load actual type classes, but we can't do this within an OSGi environment, and the bundle classloader has to be used.
So, I added a patch in TypeDescriptor.java, in order to use the bundle classloader of the lambda expression. It seems to work. 

Please review, thanks.

PS: first time I'm using github ... hope my pull request is correct ...
