### PR TITLE
OSGi version alignment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
             <Implementation-Version>${project.version}</Implementation-Version>
             <Bundle-Name>Type Tools</Bundle-Name>
             <Bundle-SymbolicName>net.jodah.typetools</Bundle-SymbolicName>
-            <Export-Package>net/jodah/typetools;version=1.0</Export-Package>
+            <Export-Package>net/jodah/typetools</Export-Package>
             <Import-Package>*</Import-Package>
           </instructions>
         </configuration>


### PR DESCRIPTION
Currently in `MANIFEST.MF` there is:
```mf
Export-Package: net.jodah.typetools;version="1.0"
```
But it should be the same version as in the Maven repository.