### PR TITLE
improved support on the android platform #18

### DIFF
--- a/src/main/java/net/jodah/typetools/TypeResolver.java
+++ b/src/main/java/net/jodah/typetools/TypeResolver.java
@@ -49,7 +49,13 @@ public final class TypeResolver {
   private static Map<String, Method> OBJECT_METHODS = new HashMap<String, Method>();
 
   static {
-    SUPPORTS_LAMBDAS = Double.valueOf(System.getProperty("java.version").substring(0, 3)) >= 1.8;
+    boolean onAndroid = false;
+    try {
+        Class.forName("android.os.Build");
+        onAndroid = Integer.valueOf(System.getProperty("java.version")) == 0;
+    } catch (ClassNotFoundException ignored) {}
+
+    SUPPORTS_LAMBDAS = !onAndroid && Double.valueOf(System.getProperty("java.version").substring(0, 3)) >= 1.8;
     if (SUPPORTS_LAMBDAS) {
       for (Method method : Object.class.getDeclaredMethods())
         OBJECT_METHODS.put(method.getName(), method);


### PR DESCRIPTION
`TypeResolver` fails to load on Android as `System.getProperty("java.version")` returns `"0"`, which causes an exception on the `substring(0,3)` call and thus prohibits the class loader from loading the class.

These changes make sure that Android is detected as a platform, and that lambdas are disabled for it, allowing for the class to be correctly loaded.