### PR TITLE
Use JaCoCo and Codecov.io to capture and display test coverage metrics 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ branches:
   only:
     - master
 
-sudo: false
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # TypeTools
 [![Build Status](https://travis-ci.org/jhalterman/typetools.svg)](https://travis-ci.org/jhalterman/typetools) 
+[![Code Coverage](https://codecov.io/github/jhalterman/typetools/coverage.svg?branch=master)](https://codecov.io/github/jhalterman/typetools?branch=master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/net.jodah/typetools/badge.svg)](https://maven-badges.herokuapp.com/maven-central/net.jodah/typetools) 
 
 A simple, zero-dependency library for working with types. Supports Java 1.6+ and Android.

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,25 @@
           </instructions>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.7.6.201602180812</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
This patch modifies the Maven build and Travis configuration to collect test coverage metrics using JaCoCo and to display those reports using Codecov.io.