### PR TITLE
Handle lambdas whose interfaces extend Serializable

### DIFF
--- a/src/test/java/net/jodah/typetools/functional/LambdaTest.java
+++ b/src/test/java/net/jodah/typetools/functional/LambdaTest.java
@@ -2,6 +2,7 @@ package net.jodah.typetools.functional;
 
 import static org.testng.Assert.assertEquals;
 
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
@@ -42,6 +43,9 @@ public class LambdaTest extends AbstractTypeResolverTest {
   };
 
   interface StrToInt extends SelectingFn<Integer, Long, String> {
+  };
+
+  interface SerializableFn<T, V> extends Function<T, V>, Serializable {
   };
 
   public static interface Function3<T, U, V, R> {
@@ -242,6 +246,10 @@ public class LambdaTest extends AbstractTypeResolverTest {
    */
   public void shouldHandlePassedLambda() {
     handlePassedFunction((UUID i) -> i.toString());
+  }
+
+  public void shouldHandlePassedSerializableLambda() {
+    handlePassedFunction((SerializableFn<UUID, String>) i -> i.toString());
   }
 
   /**


### PR DESCRIPTION
This patch addresses an issue which prevented the type parameters of lambdas from being resolved when the lambda's interface extends `Serializable` and lacks an explicit `@FunctionalInterface` annotation.

To illustrate this issue, 7f931c5 adds a failing regression test. In a nutshell, it seems that the problem stems from the fact that the lambda's constant pool contains multiple entries and the first entry that we inspected corresponded to an `<init>` method rather than the single abstract method.

To fix this issue, this patch refactors the method ref info code to always ignore `<init>` methods (previously, it only ignored `<init>` for lambdas which have auto-boxed return types). I also simplified the handling of `valueOf` in an attempt to make the code easier to understand and more linear.