### PR TITLE
More robust detection when jacoco/IntelliJ coverage is used with retrolambda.

### DIFF
--- a/src/main/java/net/jodah/typetools/TypeResolver.java
+++ b/src/main/java/net/jodah/typetools/TypeResolver.java
@@ -376,7 +376,7 @@ public final class TypeResolver {
 
           Method methodInfo;
           try {
-            methodInfo = getMethodInfo((ConstantPool) GET_CONSTANT_POOL.invoke(lambdaType));
+            methodInfo = getMethodRef((ConstantPool) GET_CONSTANT_POOL.invoke(lambdaType), lambdaType);
             if (methodInfo == null) {
               return;
             }
@@ -428,14 +428,14 @@ public final class TypeResolver {
     return javaVersion >= 1.8 && m.isDefault();
   }
 
-  private static Method getMethodInfo(ConstantPool constantPool) {
+  private static Method getMethodRef(ConstantPool constantPool, Class<?> type) {
     Method returnValue = null;
 
     for (int i = constantPool.getSize() - 1; i >= 0; i--) {
       try {
         Member member = constantPool.getMethodAt(i);
-        //skip constructors
-        if (!(member instanceof Method)) {
+        //skip constructors and members of the "type" class
+        if (member instanceof Constructor || member.getDeclaringClass().isAssignableFrom(type)) {
           continue;
         }
         returnValue = (Method) member;
@@ -452,6 +452,7 @@ public final class TypeResolver {
   }
 
   private static final Map<Class<?>, Class<?>> primitives;
+
   static {
     HashMap<Class<?>, Class<?>> types = new HashMap<Class<?>, Class<?>>();
     types.put(boolean.class, Boolean.class);
@@ -467,6 +468,6 @@ public final class TypeResolver {
   }
 
   private static Class<?> wrapPrimitives(Class<?> clazz) {
-    return clazz.isPrimitive()? primitives.get(clazz): clazz;
+    return clazz.isPrimitive() ? primitives.get(clazz) : clazz;
   }
 }

--- a/src/test/java/net/jodah/typetools/functional/LambdaTest.java
+++ b/src/test/java/net/jodah/typetools/functional/LambdaTest.java
@@ -240,11 +240,24 @@ public class LambdaTest extends AbstractTypeResolverTest {
         new Class<?>[] { String.class, Integer.class });
   }
 
+  public void shouldResolveSubclassArgumentsForConstructor() {
+    FnSubclass<String, Integer> fn = str -> new Integer(str);
+    assertEquals(TypeResolver.resolveRawArguments(Function.class, fn.getClass()),
+        new Class<?>[] { String.class, Integer.class });
+  }
+
   /**
    * Asserts that arguments can be resolved from a method reference when declared on a subclass of some type.
    */
   public void shouldResolveSubclassArgumentsForMethodRefs() {
     FnSubclass<String, Integer> fn = Integer::valueOf;
+    assertEquals(TypeResolver.resolveRawArguments(Function.class, fn.getClass()),
+        new Class<?>[] { String.class, Integer.class });
+  }
+
+  @Test(enabled = false)
+  public void shouldResolveSubclassArgumentsForConstructorRef() {
+    FnSubclass<String, Integer> fn = Integer::new;
     assertEquals(TypeResolver.resolveRawArguments(Function.class, fn.getClass()),
         new Class<?>[] { String.class, Integer.class });
   }

--- a/src/test/java/net/jodah/typetools/issues/Issue27.java
+++ b/src/test/java/net/jodah/typetools/issues/Issue27.java
@@ -18,7 +18,7 @@ public class Issue27 {
 
     Class<?>[] args = TypeResolver.resolveRawArguments(Function.class, fn.getClass());
 
-    assertEquals(args[0], Class.forName("[Ljava.lang.String;"));
+    assertEquals(args[0], String[].class);
     assertEquals(args[1], String.class);
   }
 }


### PR DESCRIPTION
1. More robust detection when jacoco/IntelliJ coverage is used with retrolambda.
2. Added disabled test which fails until constructor reference is fixed. (working on it).
3. Cosmetic changes - added curly brackets to loops and ifs.

Not a major change so no need for a new release at the moment. The important change is in [TypeTools:463](https://github.com/jhalterman/typetools/compare/master...csoroiu:master#diff-d771ba0927108c9dd334fc315832cc60R463).