### PR TITLE
Ignore only the valueOf methods used for boxing.

### DIFF
--- a/BUILDING.txt
+++ b/BUILDING.txt
@@ -1,4 +1,4 @@
-To activate 1.6 source compatibility, releaes should be performed with the -Drelease argument:
+To activate 1.6 source compatibility, release should be performed with the -Drelease argument:
 
 mvn release:prepare -Drelease
 mvn release:perform -Drelease

--- a/src/main/java/net/jodah/typetools/TypeResolver.java
+++ b/src/main/java/net/jodah/typetools/TypeResolver.java
@@ -399,14 +399,9 @@ public final class TypeResolver {
           Type returnTypeVar = m.getGenericReturnType();
           Type[] paramTypeVars = m.getGenericParameterTypes();
 
-          Member member;
-          try {
-            member = getMemberRef((ConstantPool) GET_CONSTANT_POOL.invoke(lambdaType), lambdaType);
-            if (member == null)
-              return;
-          } catch (Exception ignore) {
+          Member member = getMemberRef(lambdaType);
+          if (member == null)
             return;
-          }
 
           // Populate return type argument
           if (returnTypeVar instanceof TypeVariable) {
@@ -451,7 +446,14 @@ public final class TypeResolver {
     return JAVA_VERSION >= 1.8 && m.isDefault();
   }
 
-  private static Member getMemberRef(ConstantPool constantPool, Class<?> type) {
+  private static Member getMemberRef(Class<?> type) {
+    ConstantPool constantPool;
+    try {
+      constantPool = (ConstantPool) GET_CONSTANT_POOL.invoke(type);
+    } catch (Exception ignore) {
+      return null;
+    }
+
     Member result = null;
     for (int i = constantPool.getSize() - 1; i >= 0; i--) {
       try {


### PR DESCRIPTION
With this commit  all tests are passing when **retrolambda** is used in combination with IntelliJ & jacoco code coverage.
Without this commit the test `LambdaTest.shouldResolveSubclassArgumentsForMethodRefs` was failing when ran with code coverage after **retrolambda** was used.

Basically, we need to check if the valueOf method matches the signature of methods used for boxing operations such as `Integer.valueof(int)`, `Boolean.valueOf(boolean)` etc.

`Integer` class contains 3 `valueOf` methods out of which only `Integer.valueof(int)` is used for boxing.

Thanks