### PR TITLE
[bug] 1. Support method references for methods returning a primitive value (skip unboxing)

### DIFF
--- a/src/main/java/net/jodah/typetools/TypeResolver.java
+++ b/src/main/java/net/jodah/typetools/TypeResolver.java
@@ -461,7 +461,7 @@ public final class TypeResolver {
         // Skip SerializedLambda constructors and members of the "type" class
         if ((member instanceof Constructor
             && member.getDeclaringClass().getName().equals("java.lang.invoke.SerializedLambda"))
-            || member.getDeclaringClass().isAssignableFrom(type))
+            || member.getDeclaringClass().equals(type))
           continue;
 
         result = member;

--- a/src/test/java/net/jodah/typetools/functional/LambdaTest.java
+++ b/src/test/java/net/jodah/typetools/functional/LambdaTest.java
@@ -13,6 +13,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
 
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
@@ -97,6 +98,8 @@ public class LambdaTest extends AbstractTypeResolverTest {
     int hashCode();
 
     boolean equals(Object other);
+
+    String toString();
   }
 
   /**
@@ -255,11 +258,25 @@ public class LambdaTest extends AbstractTypeResolverTest {
         new Class<?>[] { String.class, Integer.class });
   }
 
-  @Test
   public void shouldResolveSubclassArgumentsForConstructorRef() {
     FnSubclass<String, Integer> fn = Integer::new;
     assertEquals(TypeResolver.resolveRawArguments(Function.class, fn.getClass()),
         new Class<?>[] { String.class, Integer.class });
+  }
+
+  @Test(enabled = false)
+  // fixing this will break stability when run with retrolambda + jacoco
+  // broken by constructor reference support
+  public void shouldResolveObjectClassMethodRef() {
+    Function<?, String> fn = Object::toString;
+    assertEquals(TypeResolver.resolveRawArguments(Function.class, fn.getClass()),
+        new Class<?>[] { Object.class, String.class });
+  }
+
+  public void shouldResolvePrimitiveReturnValue() {
+    ToDoubleFunction<String> fn = Double::valueOf; //this method returns Integer, thus unboxing takes place
+    assertEquals(TypeResolver.resolveRawArguments(ToDoubleFunction.class, fn.getClass()),
+        new Class<?>[] { String.class });
   }
 
   public void shouldResolveTransposedSubclassArguments() {

--- a/src/test/java/net/jodah/typetools/functional/LambdaTest.java
+++ b/src/test/java/net/jodah/typetools/functional/LambdaTest.java
@@ -264,13 +264,16 @@ public class LambdaTest extends AbstractTypeResolverTest {
         new Class<?>[] { String.class, Integer.class });
   }
 
-  @Test(enabled = false)
-  // fixing this will break stability when run with retrolambda + jacoco
-  // broken by constructor reference support
   public void shouldResolveObjectClassMethodRef() {
     Function<?, String> fn = Object::toString;
     assertEquals(TypeResolver.resolveRawArguments(Function.class, fn.getClass()),
         new Class<?>[] { Object.class, String.class });
+  }
+
+  public void shouldResolveObjectClassConstructorRef() {
+    Supplier<?> fn = Object::new;
+    assertEquals(TypeResolver.resolveRawArguments(Supplier.class, fn.getClass()),
+        new Class<?>[] { Object.class });
   }
 
   public void shouldResolvePrimitiveReturnValue() {


### PR DESCRIPTION
1. Support method references for methods returning a primitive value (skip unboxing). I stepped into this issue while trying to use [ByteBuddy](https://github.com/raphw/byte-buddy) to find out the method reference for lambda's, but I wasn't successful because of the issue raphw/byte-buddy#205. 
2. Updated: Object class method and constructor reference detection was fixed. 
Known issue is that method and constructor reference does not work fine with **retrolambda+jacoco**, but results are compatible with the expected class type.
 ~~Object class method references are not resolved correctly (e.g. `Object::toString`)~~
   - ~~I added failing(disabled) test~~
   - ~~As mentioned in a comment inside the test, this was broken when constructor reference was added.~~
   - ~~I will try to fix it at some point, but currently, this should not be a problem because the `resolveRawArguments` method returns `Unknown` and one can fallback on using `Object` which I don't consider it bad.~~

