### PR TITLE
Fix #47

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,20 @@
 sudo: false
 
 language: java
-install: mvn install -DskipTests=true -Dgpg.skip=true
 
-jdk:
-  - oraclejdk8
+install: mvn install -Dgpg.skip=true
+
+jobs:
+  include:
+  - stage: adoptopenjdk.net - Eclipse OpenJ9
+    env: 
+      - MAVEN_OPTS="--add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED"    
+    before_install:
+      - unset -v _JAVA_OPTIONS
+      - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh 
+      - source install-jdk.sh --url $(curl --silent https://api.adoptopenjdk.net/v2/binary/nightly/openjdk11\?openjdk_impl\=openj9\&os\=linux\&arch\=x64\&release\=latest\&type\=jdk | grep 'binary_link' | grep -Eo '(http|https)://[^"]+' | head -1)
+  - stage: jdk.java.net - OpenJDK - GPL
+    jdk: oraclejdk8
 
 notifications:
   email: false

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,17 @@
   </dependencies>
 
   <build>
+	<pluginManagement>
+		<plugins>
+			<plugin>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.0.0-M3</version>
+				<configuration>
+					<forkCount>0</forkCount>
+				</configuration>
+			</plugin>
+		</plugins>
+	</pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -108,7 +119,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.9</version>
+        <version>0.8.2</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
Originally the static initialization was assuming that the ConstantPool
would be accessible via Class.getConstantPool(). However such method
only exists in the Oracle JDK and is not provided by the IBM OpenJ9 JDK.

But, both JDKs define an interface JavaLangAccess which offers method
getConstantPool( Class c ) that returns the constant pool for the given
class and the JavaLangAccess can be obtained via factory method
SharedSecrets.getJavaLangAccess().

Both SharedSecrets and JavaLangAccess have been relocated from sun.*
packages to jdk.internal.* packages in Java 9 or later.

Now:
- the code obtains the pool using the right classes from the right
  packages and the behavior is therefore portable across all JDKs
  available at the time of writing
- usage of Unsafe has been also removed
- Surefire plugin updated to be able to run TestNG tests.
- Surefire tests run in same JVM as maven to (forkedCount=0) to ensure
  that MAVEN_OPTS are propagated to test execution
- Travis file changed to also run tests on IBM OpenJ9 11.