### PR TITLE
Non-equality on recursive resolved types overflows stack

### DIFF
--- a/src/main/java/net/jodah/typetools/ReifiedParameterizedType.java
+++ b/src/main/java/net/jodah/typetools/ReifiedParameterizedType.java
@@ -2,15 +2,35 @@ package net.jodah.typetools;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.util.Arrays;
 
 class ReifiedParameterizedType implements ParameterizedType {
     private final ParameterizedType original;
     private final Type[] reifiedTypeArguments;
+    private final boolean[] loop;
+    private int reified = 0;
 
     ReifiedParameterizedType(ParameterizedType original) {
       this.original = original;
       this.reifiedTypeArguments = new Type[original.getActualTypeArguments().length];
+      this.loop = new boolean[original.getActualTypeArguments().length];
+    }
+
+    /**
+     * This method is used to set reified types as they are processed. For example,
+     * When reifying some {@code T<E1, E2>}, in order to reify {@code T} we need
+     * to reify first {@code E1} and then {@code E2} in order. The reified counterpart
+     * of {@code T} is allocated before, and then the results from reifying {@code E1}
+     * and {@code E2} are added through this method.
+     * @param type the reification result to be added
+     */
+  /* package-private */ void addReifiedTypeArgument(Type type) {
+      if (reified >= reifiedTypeArguments.length) {
+        return;
+      }
+      if (type == this) {
+        loop[reified] = true;
+      }
+      reifiedTypeArguments[reified++] = type;
     }
 
     @Override
@@ -29,20 +49,15 @@ class ReifiedParameterizedType implements ParameterizedType {
     }
 
     /**
-     * NOTE: This method should only be called once per instance.
+     * Keep this consistent with {@link sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl#toString}
      */
-    void setReifiedTypeArguments(Type[] reifiedTypeArguments) {
-      System.arraycopy(reifiedTypeArguments, 0, this.reifiedTypeArguments, 0, this.reifiedTypeArguments.length);
-    }
-
-    /** Keep this consistent with {@link sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl#toString} */
     @Override
     public String toString() {
       final Type ownerType = getOwnerType();
       final Type rawType = getRawType();
       final Type[] actualTypeArguments = getActualTypeArguments();
 
-      StringBuilder sb = new StringBuilder();
+      final StringBuilder sb = new StringBuilder();
 
       if (ownerType != null) {
         if (ownerType instanceof Class) {
@@ -51,13 +66,15 @@ class ReifiedParameterizedType implements ParameterizedType {
           sb.append(ownerType.toString());
         }
 
-        sb.append(".");
+        sb.append("$");
 
         if (ownerType instanceof ParameterizedType) {
           // Find simple name of nested type by removing the
           // shared prefix with owner.
           sb.append(rawType.getTypeName()
               .replace(((ParameterizedType) ownerType).getRawType().getTypeName() + "$", ""));
+        } else if (rawType instanceof Class){
+          sb.append(((Class) rawType).getSimpleName());
         } else {
           sb.append(rawType.getTypeName());
         }
@@ -68,13 +85,27 @@ class ReifiedParameterizedType implements ParameterizedType {
       if (actualTypeArguments != null && actualTypeArguments.length > 0) {
         sb.append("<");
 
-        boolean first = true;
-        for (Type t: actualTypeArguments) {
-          if (!first) {
+        for (int i = 0; i < actualTypeArguments.length; i++) {
+          if (i != 0) {
             sb.append(", ");
           }
-          sb.append(t == null ? "null" : t.getTypeName());
-          first = false;
+
+          final Type t = actualTypeArguments[i];
+
+          if (i >= reified) {
+            sb.append("?");
+          } else if (t == null) {
+            sb.append("null");
+          } else if (loop[i]) {
+            // Instead of recursing into this argument, which would overflow the stack,
+            // print three dots to indicate "self-loop structure is here". Note
+            // that if the full string examined is some other type that contains this
+            // instance, then the notation is ambiguous: We don't know which type
+            // is self-loop where.
+            sb.append("...");
+          } else {
+            sb.append(t.getTypeName());
+          }
         }
         sb.append(">");
       }
@@ -92,14 +123,39 @@ class ReifiedParameterizedType implements ParameterizedType {
       }
 
       ReifiedParameterizedType that = (ReifiedParameterizedType) o;
-      return original.equals(that.original) &&
-          Arrays.equals(reifiedTypeArguments, that.reifiedTypeArguments);
+      if (!original.equals(that.original)) {
+        return false;
+      }
+
+      if (reifiedTypeArguments.length != that.reifiedTypeArguments.length) {
+        return false;
+      }
+
+      for (int i = 0; i < reifiedTypeArguments.length; i++) {
+        if (loop[i] != that.loop[i]) {
+          return false;
+        }
+        if (loop[i]) {
+          continue;
+        }
+        if (reifiedTypeArguments[i] != that.reifiedTypeArguments[i]) {
+          return false;
+        }
+      }
+      return true;
     }
 
     @Override
     public int hashCode() {
       int result = original.hashCode();
-      result = 31 * result + Arrays.hashCode(reifiedTypeArguments);
+      for (int i = 0; i < reifiedTypeArguments.length; i++) {
+        if (loop[i]) {
+          continue;
+        }
+        if (reifiedTypeArguments[i] instanceof ReifiedParameterizedType) {
+          result = 31 * result + reifiedTypeArguments[i].hashCode();
+        }
+      }
       return result;
     }
   }

--- a/src/test/java/net/jodah/typetools/TypeResolverTest.java
+++ b/src/test/java/net/jodah/typetools/TypeResolverTest.java
@@ -356,10 +356,13 @@ public class TypeResolverTest extends AbstractTypeResolverTest {
     assert parent.getActualTypeArguments()[0] instanceof ParameterizedType;
     ParameterizedType parameterizedType = (ParameterizedType)parent.getActualTypeArguments()[0];
     assert parameterizedType.getActualTypeArguments()[0] == parameterizedType;
+    assert parameterizedType.getActualTypeArguments()[0].equals(parameterizedType);
 
     assert parent.getActualTypeArguments()[1] instanceof ParameterizedType;
-    parameterizedType = (ParameterizedType)parent.getActualTypeArguments()[1];
-    assert parameterizedType.getActualTypeArguments()[0] == parameterizedType;
+    ParameterizedType parameterizedType2 = (ParameterizedType)parent.getActualTypeArguments()[1];
+    assert parameterizedType2.getActualTypeArguments()[0] == parameterizedType2;
+
+    assert !parameterizedType.equals(parameterizedType2);
   }
 
   public void shouldReifyRecursiveOnSecondBound() {


### PR DESCRIPTION
To start with, I slightly extended a test case by adding two calls to `ReifiedParameterizedType#equals`. One of them succeeds, since the two passed parameters are referentially equal. However in the second case, I expect `equals` to return `false`, since the two parameters are not equal, with the unanticipated failure by stack overflow.

The reason for this is self-referentiality in `ReifiedParameterizedType`, which makes `equals`, `toString` and probably also `hashCode` go awry.

The format of this report is a PR, since I wanted to get across the demonstrating example, but really my intention is to point out an issue in the the `reify` facility.

Note that [ClassMate opted to go for a special class `ResolvedRecursiveType` to cover this case.](https://github.com/FasterXML/java-classmate/blob/master/src/main/java/com/fasterxml/classmate/types/ResolvedRecursiveType.java)