### PR TITLE
Fix lambda inference on openj9 and Java 12 and higher.

### DIFF
--- a/src/main/java/net/jodah/typetools/TypeResolver.java
+++ b/src/main/java/net/jodah/typetools/TypeResolver.java
@@ -65,7 +65,7 @@ public final class TypeResolver {
     JAVA_VERSION = Double.parseDouble(System.getProperty("java.specification.version", "0"));
 
     try {
-      Unsafe unsafe = AccessController.doPrivileged(new PrivilegedExceptionAction<Unsafe>() {
+      final Unsafe unsafe = AccessController.doPrivileged(new PrivilegedExceptionAction<Unsafe>() {
         @Override
         public Unsafe run() throws Exception {
           final Field f = Unsafe.class.getDeclaredField("theUnsafe");
@@ -90,7 +90,7 @@ public final class TypeResolver {
           sharedSecretsName = "jdk.internal.misc.SharedSecrets";
           // access control got strengthed in Java 9, but can be circumvented with Unsafe.
           Field overrideField = AccessibleObject.class.getDeclaredField("override");
-          long overrideFieldOffset = unsafe.objectFieldOffset(overrideField);
+          final long overrideFieldOffset = unsafe.objectFieldOffset(overrideField);
           accessSetter = new AccessMaker() {
             @Override
             public void makeAccessible(AccessibleObject accessibleObject) {
@@ -105,11 +105,11 @@ public final class TypeResolver {
           long implLookupFieldOffset = unsafe.staticFieldOffset(implLookupField);
           Object lookupStaticFieldBase = unsafe.staticFieldBase(implLookupField);
           MethodHandles.Lookup implLookup = (MethodHandles.Lookup) unsafe.getObject(lookupStaticFieldBase, implLookupFieldOffset);
-          MethodHandle overrideSetter = implLookup.findSetter(AccessibleObject.class, "override", boolean.class);
+          final MethodHandle overrideSetter = implLookup.findSetter(AccessibleObject.class, "override", boolean.class);
           accessSetter = new AccessMaker() {
             @Override
             public void makeAccessible(AccessibleObject object) throws Throwable {
-              overrideSetter.invoke(object, true);
+              overrideSetter.invoke(new Object[] {object, true});
             }
         };
       }

--- a/src/main/java/net/jodah/typetools/TypeResolver.java
+++ b/src/main/java/net/jodah/typetools/TypeResolver.java
@@ -51,6 +51,7 @@ public final class TypeResolver {
       .synchronizedMap(new WeakHashMap<Class<?>, Reference<Map<TypeVariable<?>, Type>>>());
   private static volatile boolean CACHE_ENABLED = true;
   private static boolean RESOLVES_LAMBDAS;
+  private static Object JAVA_LANG_ACCESS;
   private static Method GET_CONSTANT_POOL;
   private static Method GET_CONSTANT_POOL_SIZE;
   private static Method GET_CONSTANT_POOL_METHOD_AT;
@@ -72,22 +73,29 @@ public final class TypeResolver {
         }
       });
 
-      GET_CONSTANT_POOL = Class.class.getDeclaredMethod("getConstantPool");
+      Field overrideField = AccessibleObject.class.getDeclaredField("override");
+      long overrideFieldOffset = unsafe.objectFieldOffset(overrideField);
+
+      String sharedSecretsName = JAVA_VERSION < 9 ? "sun.misc.SharedSecrets" : "jdk.internal.misc.SharedSecrets";
+      Class<?> sharedSecretsClass = Class.forName(sharedSecretsName);
+      Method javaLangAccessGetter = sharedSecretsClass.getMethod("getJavaLangAccess");
+      unsafe.putBoolean(javaLangAccessGetter, overrideFieldOffset, true);
+      Object access = javaLangAccessGetter.invoke(null);
+      GET_CONSTANT_POOL = access.getClass().getMethod("getConstantPool", Class.class);
+
       String constantPoolName = JAVA_VERSION < 9 ? "sun.reflect.ConstantPool" : "jdk.internal.reflect.ConstantPool";
       Class<?> constantPoolClass = Class.forName(constantPoolName);
       GET_CONSTANT_POOL_SIZE = constantPoolClass.getDeclaredMethod("getSize");
       GET_CONSTANT_POOL_METHOD_AT = constantPoolClass.getDeclaredMethod("getMethodAt", int.class);
 
       // setting the methods as accessible
-      Field overrideField = AccessibleObject.class.getDeclaredField("override");
-      long overrideFieldOffset = unsafe.objectFieldOffset(overrideField);
       unsafe.putBoolean(GET_CONSTANT_POOL, overrideFieldOffset, true);
       unsafe.putBoolean(GET_CONSTANT_POOL_SIZE, overrideFieldOffset, true);
       unsafe.putBoolean(GET_CONSTANT_POOL_METHOD_AT, overrideFieldOffset, true);
 
       // additional checks - make sure we get a result when invoking the Class::getConstantPool and
       // ConstantPool::getSize on a class
-      Object constantPool = GET_CONSTANT_POOL.invoke(Object.class);
+      Object constantPool = GET_CONSTANT_POOL.invoke(JAVA_LANG_ACCESS, Object.class);
       GET_CONSTANT_POOL_SIZE.invoke(constantPool);
 
       for (Method method : Object.class.getDeclaredMethods())
@@ -669,7 +677,7 @@ public final class TypeResolver {
   private static Member getMemberRef(Class<?> type) {
     Object constantPool;
     try {
-      constantPool = GET_CONSTANT_POOL.invoke(type);
+      constantPool = GET_CONSTANT_POOL.invoke(JAVA_LANG_ACCESS, type);
     } catch (Exception ignore) {
       return null;
     }

--- a/src/main/java/net/jodah/typetools/TypeResolver.java
+++ b/src/main/java/net/jodah/typetools/TypeResolver.java
@@ -109,7 +109,7 @@ public final class TypeResolver {
           accessSetter = new AccessMaker() {
             @Override
             public void makeAccessible(AccessibleObject object) throws Throwable {
-              overrideSetter.invoke(new Object[] {object, true});
+              overrideSetter.invokeWithArguments(new Object[] {object, true});
             }
         };
       }


### PR DESCRIPTION
I fixed the problem in my last PR (I feel like I'd fixed that locally and forgot to add it to git, whoops) and also added support for lambda inference on Java 12 and higher by changing the strategy for circumventing access control on those versions.