### PR TITLE
Fixed resolve lambda type on java 12 and higher issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ install: mvn install -DskipTests=true -Dgpg.skip=true
 jdk:
   - openjdk8
   - openjdk11
+  - openjdk14
 
 notifications:
   email: false

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.7</version>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -116,12 +116,13 @@
             -notimestamp
             -link http://docs.oracle.com/javase/8/docs/api/
           </additionalparam>
+          <failOnError>false</failOnError>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.2</version>
+        <version>0.8.6</version>
         <executions>
           <execution>
             <goals>

--- a/src/main/java/net/jodah/typetools/ConstantPools.java
+++ b/src/main/java/net/jodah/typetools/ConstantPools.java
@@ -1,0 +1,92 @@
+package net.jodah.typetools;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Method;
+
+public class ConstantPools {
+
+  public static Result resolveConstantPoolMethods() {
+    double javaVersion = Double.parseDouble(System.getProperty("java.specification.version", "0"));
+    if (javaVersion < 9) {
+      return resolveByReflection();
+    } else {
+      return resolveByLookup();
+    }
+  }
+
+  public static Result resolveByReflection() {
+    try {
+      Class<?> constantPoolClass = Class.forName("sun.reflect.ConstantPool");
+      Method getConstantPool = Class.class.getDeclaredMethod("getConstantPool");
+      getConstantPool.setAccessible(true);
+      Method getConstantPoolSize = constantPoolClass.getDeclaredMethod("getSize");
+      getConstantPoolSize.setAccessible(true);
+      Method getConstantPoolMethodAt = constantPoolClass
+          .getDeclaredMethod("getMethodAt", int.class);
+      getConstantPoolMethodAt.setAccessible(true);
+      return new Result(getConstantPool, getConstantPoolSize, getConstantPoolMethodAt);
+    } catch (Exception e) {
+      return new Result(e);
+    }
+  }
+
+  public static Result resolveByLookup() {
+    try {
+      Method privateLookupIn = MethodHandles.class.getMethod("privateLookupIn", Class.class, Lookup.class);
+      Lookup lookup = (Lookup) privateLookupIn.invoke(null, AccessibleObject.class, MethodHandles.lookup());
+      MethodHandle overrideSetter = lookup.findSetter(AccessibleObject.class, "override", boolean.class);
+
+      Class<?> constantPoolClass = Class.forName("jdk.internal.reflect.ConstantPool");
+      Method getConstantPool = Class.class.getDeclaredMethod("getConstantPool");
+      overrideSetter.invoke(getConstantPool, true);
+      Method getConstantPoolSize = constantPoolClass.getDeclaredMethod("getSize");
+      overrideSetter.invoke(getConstantPoolSize, true);
+      Method getConstantPoolMethodAt = constantPoolClass.getDeclaredMethod("getMethodAt", int.class);
+      overrideSetter.invoke(getConstantPoolMethodAt, true);
+      return new Result(getConstantPool, getConstantPoolSize, getConstantPoolMethodAt);
+    } catch (Throwable e) {
+      return new Result(e);
+    }
+  }
+
+  public static class Result {
+    private final Throwable failure;
+    private final Method getConstantPool;
+    private final Method getConstantPoolSize;
+    private final Method getConstantPoolMethodAt;
+
+    public Result(Throwable failure) {
+      this.failure = failure;
+      this.getConstantPool = null;
+      this.getConstantPoolSize = null;
+      this.getConstantPoolMethodAt = null;
+    }
+
+    public Result(Method getConstantPool, Method getConstantPoolSize,
+        Method getConstantPoolMethodAt) {
+      this.failure = null;
+      this.getConstantPool = getConstantPool;
+      this.getConstantPoolSize = getConstantPoolSize;
+      this.getConstantPoolMethodAt = getConstantPoolMethodAt;
+    }
+
+    public boolean resolved() {
+      return failure == null;
+    }
+
+    public Method getGetConstantPool() {
+      return getConstantPool;
+    }
+
+    public Method getGetConstantPoolSize() {
+      return getConstantPoolSize;
+    }
+
+    public Method getGetConstantPoolMethodAt() {
+      return getConstantPoolMethodAt;
+    }
+  }
+}


### PR DESCRIPTION
Java 12 introduces a security update wihch disallow getting fields from
java internal api, like Field, Method, AccessObject. Typetools relies on
the field 'override' in AccessObject to grant the access right, so we
can use the ConstantPool to resolve types from lambda expression.

But we cannot get the 'override' field by 'Class.getDeclaredField',
we can use the `MethodHandles.Lookup` to get the field.

See: https://bugs.openjdk.java.net/browse/JDK-8210522

Resolved: #52, #70
